### PR TITLE
issue#7 A tree builder without a root node is deprecated since sf 4.2

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('tiloweb_pagination');
+        $treeBuilder = new TreeBuilder('tiloweb_pagination');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()


### PR DESCRIPTION
and will not be supported anymore in 5.0 fix

see: https://github.com/Tiloweb/SymfonyPaginationBundle/issues/7