### PR TITLE
Feature/backwards compatibility

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,7 +19,7 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('tiloweb_pagination');
 
-        $rootNode = method_exists($treeBuilder, 'getRootNode') ? $treeBuilder->getRootNode(); : $treeBuilder->root('tiloweb_pagination');
+        $rootNode = method_exists($treeBuilder, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('tiloweb_pagination');
         
         $rootNode
             ->children()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,8 +18,12 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('tiloweb_pagination');
-        
-        $rootNode = $treeBuilder->getRootNode();
+
+        if(method_exists($treeBuilder, 'getRootNode')) {
+          $rootNode = $treeBuilder->getRootNode();
+        } else {
+          $rootNode = $treeBuilder->root('tiloweb_pagination');
+        }
         
         $rootNode
             ->children()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,11 +19,7 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('tiloweb_pagination');
 
-        if(method_exists($treeBuilder, 'getRootNode')) {
-          $rootNode = $treeBuilder->getRootNode();
-        } else {
-          $rootNode = $treeBuilder->root('tiloweb_pagination');
-        }
+        $rootNode = method_exists($treeBuilder, 'getRootNode') ? $treeBuilder->getRootNode(); : $treeBuilder->root('tiloweb_pagination');
         
         $rootNode
             ->children()


### PR DESCRIPTION
Hey Tiloweb,

there seems to be a problem with backwards compatibility in Symfony 3.x projects. I just applied a quick fix for the problem. The second commit is reducing the lines of code used for solving the problem. I hope it is ok that I opened the PR without creating an issue first.

* Fixes a backwards compatibility issue in the bundle configuration.php
file that let to problems with symfony versions in the 3.x range. The
problem manifested in not being able to read the configration and so
blocking the use of the symfony bin/console command. This patch
refactores the configuration code to check for the getRootNode()
function first and in a negative case it will prepare a default root
node value which is the bundles root node from the treeBuilder.