### PR TITLE
"Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1

### DIFF
--- a/DependencyInjection/TilowebPaginationExtension.php
+++ b/DependencyInjection/TilowebPaginationExtension.php
@@ -4,7 +4,7 @@ namespace Tiloweb\PaginationBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
 /**


### PR DESCRIPTION
Noticed this in the Profiler:

`The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "Tiloweb\PaginationBundle\DependencyInjection\TilowebPaginationExtension".`

Switched to `Symfony\Component\DependencyInjection\Extension\Extension` as mentioned and it seems to work perfectly fine.